### PR TITLE
Move master back to Mirage 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 sudo: false
 env:
  global:
-   - EXTRA_REMOTES="git://github.com/mirage/mirage-dev.git"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - PACKAGE="hvsock"
  matrix:

--- a/lwt/lwt_hvsock.ml
+++ b/lwt/lwt_hvsock.ml
@@ -151,7 +151,7 @@ let connect t addr = match t with
       >>= fun () ->
       Lwt.return true in
     let timeout_t =
-      Time.sleep_ns (Duration.of_sec 1)
+      Time.sleep 1.
       >>= fun () ->
       Lwt.return false in
     Lwt.choose [ connect_t; timeout_t ]

--- a/lwt_unix/flow_lwt_unix_time.ml
+++ b/lwt_unix/flow_lwt_unix_time.ml
@@ -16,4 +16,4 @@
  *)
 type 'a io = 'a Lwt.t
 
-let sleep_ns ns = Lwt_unix.sleep (Duration.to_f ns)
+let sleep = Lwt_unix.sleep

--- a/opam
+++ b/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt"
   "base-unix"
   "cmdliner"
-  "mirage-types-lwt" {>="3.0"}
+  "mirage-types-lwt" {>= "2.0" & <"3.0"}
   "mirage-flow"
   "cstruct"
   "duration"

--- a/src/hvcat.ml
+++ b/src/hvcat.ml
@@ -58,7 +58,7 @@ let buffer_size = 4096
 
 module Time = struct
   type 'a io = 'a Lwt.t
-  let sleep_ns ns = Lwt_unix.sleep (Duration.to_f ns)
+  let sleep = Lwt_unix.sleep
 end
 module Hv = Lwt_hvsock.Make(Time)(Lwt_preemptive)
 


### PR DESCRIPTION
While we're waiting for Mirage 3, we need to be able to make and release bug fixes for Mirage 2. So we'll revert the API change in master but keep it in a `mirage-3.0` branch which can be referred to in [mirage/mirage-dev]