### PR TITLE
Return `ETIMEDOUT` when `connect` hits a timeout

### DIFF
--- a/lib/hvsock.ml
+++ b/lib/hvsock.ml
@@ -66,7 +66,7 @@ external do_bind: Unix.file_descr -> string -> string -> unit = "stub_hvsock_bin
 
 external do_accept: Unix.file_descr -> Unix.file_descr * string * string = "stub_hvsock_accept"
 
-external do_connect: Unix.file_descr -> string -> string -> unit = "stub_hvsock_connect"
+external do_connect: int -> Unix.file_descr -> string -> string -> unit = "stub_hvsock_connect"
 
 let create = do_socket
 
@@ -77,4 +77,4 @@ let accept fd =
   let vmid = vmid_of_string vmid in
   fd, { vmid; serviceid }
 
-let connect fd { vmid; serviceid } = do_connect fd (string_of_vmid vmid) serviceid
+let connect ?(timeout_ms=300) fd { vmid; serviceid } = do_connect timeout_ms fd (string_of_vmid vmid) serviceid

--- a/lib/hvsock.mli
+++ b/lib/hvsock.mli
@@ -39,8 +39,9 @@ val bind: Unix.file_descr -> sockaddr -> unit
 val accept: Unix.file_descr -> Unix.file_descr * sockaddr
 (** [accept fd] accepts a single connection *)
 
-val connect: Unix.file_descr -> sockaddr -> unit
-(** [connect fd sockaddr] connects to a remote partition. Note this
-    has been observed to block forever if the server is not running
-    when this call is executed, even if the server starts up afterwards.
-    The workaround seems to be to close the fd and try again. *)
+val connect: ?timeout_ms:int -> Unix.file_descr -> sockaddr -> unit
+(** [connect ?timeout_ms fd sockaddr] connects to a remote partition.
+    Since the raw socket call can block forever if the server is not
+    running when the call is executed (even if the server starts up afterwards)
+    there is a default timeout of 300ms. On timeout this will raise
+    [Unix_error(Unix.ETIMEDOUT)] *)

--- a/lib/hvsock_stubs.c
+++ b/lib/hvsock_stubs.c
@@ -33,6 +33,8 @@
 #ifndef WIN32
 #include <fcntl.h>
 #include <poll.h>
+#else
+#define ETIMEDOUT -WSAETIMEDOUT
 #endif
 
 /* Helper macros for parsing/printing GUIDs */

--- a/lib/hvsock_stubs.c
+++ b/lib/hvsock_stubs.c
@@ -180,7 +180,6 @@ CAMLprim value stub_hvsock_connect(value sock, value vmid, value serviceid){
     {
       win32_maperr(WSAGetLastError());
       uerror("connect", Nothing);
-      caml_failwith("Failed to connect");
     } else {
       FD_ZERO(&fds);
 		  FD_SET(fd, &fds);
@@ -230,14 +229,12 @@ CAMLprim value stub_hvsock_connect(value sock, value vmid, value serviceid){
     if (err != EINPROGRESS)
     {
       uerror("connect", Nothing);
-      caml_failwith("Failed to connect");
     }
     res = poll(&pollInfo, 1, 300);
     if (res == -1)
     {
       win32_maperr(WSAGetLastError());
       uerror("connect", Nothing);
-      caml_failwith("Failed to connect");
     }
     if (res == 0)
     {

--- a/lib/hvsock_stubs.c
+++ b/lib/hvsock_stubs.c
@@ -231,13 +231,20 @@ CAMLprim value stub_hvsock_connect(value sock, value vmid, value serviceid){
     {
       uerror("connect", Nothing);
       caml_failwith("Failed to connect");
-    } 
-    else if (poll(&pollInfo, 1, 300) != 1)
+    }
+    res = poll(&pollInfo, 1, 300);
+    if (res == -1)
     {
       win32_maperr(WSAGetLastError());
       uerror("connect", Nothing);
       caml_failwith("Failed to connect");
-    }    
+    }
+    if (res == 0)
+    {
+      /* Timeout */
+      errno = ETIMEDOUT;
+      uerror("connect", Nothing);
+    }
   }
   fcntl(fd, F_SETFL, flags);
   CAMLreturn(Val_unit);

--- a/lib/hvsock_stubs.c
+++ b/lib/hvsock_stubs.c
@@ -186,10 +186,15 @@ CAMLprim value stub_hvsock_connect(value sock, value vmid, value serviceid){
 		  FD_SET(fd, &fds);
       timeout.tv_sec = 0;
       timeout.tv_usec = 1000 * 300; // 300ms is long enough for hv_socks
-      if (select(1, NULL, &fds, NULL, &timeout) != 1){
+      res = select(1, NULL, &fds, NULL, &timeout);
+      if (res == SOCKET_ERROR) {
         win32_maperr(WSAGetLastError());
         uerror("connect", Nothing);
-        caml_failwith("Failed to connect");
+      }
+      if (res == 0) {
+        /* Timeout */
+        errno = ETIMEDOUT;
+        uerror("connect", Nothing);
       }
     }
   }

--- a/lwt/lwt_hvsock.ml
+++ b/lwt/lwt_hvsock.ml
@@ -143,14 +143,7 @@ let accept = function
 let connect ?timeout_ms t addr = match t with
   | { fd = None } -> Lwt.fail (Unix.Unix_error(Unix.EBADF, "connect", ""))
   | { fd = Some x } ->
-    try
-      connect ?timeout_ms x addr;
-      Lwt.return_unit
-    with
-      Failure _ ->  begin
-        close t
-        >>= fun() -> Lwt.fail (Unix.Unix_error(Unix.ECONNREFUSED, "connect", ""))
-      end
+    detach (connect ?timeout_ms x) addr
 
 let read t buf = match t with
   | { fd = None } -> Lwt.fail (Unix.Unix_error(Unix.EBADF, "read", ""))

--- a/lwt/lwt_hvsock.ml
+++ b/lwt/lwt_hvsock.ml
@@ -38,7 +38,7 @@ module type HVSOCK = sig
   val bind: t -> sockaddr -> unit
   val listen: t -> int -> unit
   val accept: t -> (t * sockaddr) Lwt.t
-  val connect: t -> sockaddr -> unit Lwt.t
+  val connect: ?timeout_ms:int -> t -> sockaddr -> unit Lwt.t
   val read: t -> Cstruct.t -> int Lwt.t
   val write: t -> Cstruct.t -> int Lwt.t
   val close: t -> unit Lwt.t
@@ -140,11 +140,11 @@ let accept = function
     >>= fun (y, addr) ->
     Lwt.return (make y, addr)
 
-let connect t addr = match t with
+let connect ?timeout_ms t addr = match t with
   | { fd = None } -> Lwt.fail (Unix.Unix_error(Unix.EBADF, "connect", ""))
   | { fd = Some x } ->
-    try 
-      connect x addr;
+    try
+      connect ?timeout_ms x addr;
       Lwt.return_unit
     with
       Failure _ ->  begin

--- a/lwt/lwt_hvsock.mli
+++ b/lwt/lwt_hvsock.mli
@@ -38,8 +38,8 @@ module type HVSOCK = sig
   val accept: t -> (t * sockaddr) Lwt.t
   (** [accept t] accepts a single connection *)
 
-  val connect: t -> sockaddr -> unit Lwt.t
-  (** [connect t sockaddr] connects to a remote partition *)
+  val connect: ?timeout_ms:int -> t -> sockaddr -> unit Lwt.t
+  (** [connect ?timeout_ms t sockaddr] connects to a remote partition *)
 
   val read: t -> Cstruct.t -> int Lwt.t
   (** [read t buf] reads as many bytes as available into [buf] returning


### PR DESCRIPTION
This PR

- return a better error message when `select` or `poll` times out
- drop and re-acquire the OCaml heap lock around blocking `connect` `select` and `poll` which should prevent concurrent OCaml threads freezing
- remove some redundant but harmless `caml_failwith`