### PR TITLE
Re-add a blocking connect implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # OCaml bindings for Hyper-V AF_VSOCK
 
+[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
+
 These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
 and Windows.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+platform:
+  - x86
+
+environment:
+  CYG_ROOT: "C:\\cygwin"
+  CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+  TESTS: "false"
+  OPAM_SWITCH: "4.03.0+mingw64c"
+
+install:
+  - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils.3.5-1 -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core"
+
+build_script:
+  - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/lib/hvsock.ml
+++ b/lib/hvsock.ml
@@ -66,7 +66,8 @@ external do_bind: Unix.file_descr -> string -> string -> unit = "stub_hvsock_bin
 
 external do_accept: Unix.file_descr -> Unix.file_descr * string * string = "stub_hvsock_accept"
 
-external do_connect: int -> Unix.file_descr -> string -> string -> unit = "stub_hvsock_connect"
+external do_connect_blocking: Unix.file_descr -> string -> string -> unit = "stub_hvsock_connect_blocking"
+external do_connect_nonblocking: int -> Unix.file_descr -> string -> string -> unit = "stub_hvsock_connect_nonblocking"
 
 let create = do_socket
 
@@ -77,4 +78,7 @@ let accept fd =
   let vmid = vmid_of_string vmid in
   fd, { vmid; serviceid }
 
-let connect ?(timeout_ms=300) fd { vmid; serviceid } = do_connect timeout_ms fd (string_of_vmid vmid) serviceid
+let connect ?timeout_ms fd { vmid; serviceid } =
+  ( match timeout_ms with
+    | None -> do_connect_blocking
+    | Some t -> do_connect_nonblocking t ) fd (string_of_vmid vmid) serviceid


### PR DESCRIPTION
If a `timeout_ms` parameter is supplied then we will use the non-blocking
socket implementation. If there is no `timeout_ms` then we will use a
regular blocking connect.

Signed-off-by: David Scott <dave.scott@docker.com>