### PR TITLE
Add missing dep to base-threads

### DIFF
--- a/opam
+++ b/opam
@@ -19,6 +19,7 @@ remove: ["ocamlfind" "remove" "hvsock"]
 
 depends: [
   "base-bytes"
+  "base-threads"
   "lwt" {>= "2.4.7"}
   "logs"
   "fmt"


### PR DESCRIPTION
This is needed because lwt.preemptive is used