### PR TITLE
Update dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 1.0.2 (2018-06-14)
+
+- Remove unnecessary dependency on `Bos`
+- Require lwt 3.2.0 and later following the removal of lwt.preemptive
+
 ## 1.0.1 (2017-09-15)
 
 - Move the Unix-independent module `Lwt_hvsock_main_thread` to `hvsock.lwt`

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -29,7 +29,6 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "cstruct" {>= "2.4.0"}
   "duration"
-  "bos"
   "jbuilder" {build & >="1.0+beta10"}
   "alcotest" {test & >= "0.4.0"}
 ]

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -21,7 +21,7 @@ depends: [
   "base-bytes"
   "base-threads"
   "base-unix"
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "3.2.0"}
   "logs"
   "fmt"
   "cmdliner"

--- a/lwt/flow_lwt_hvsock.ml
+++ b/lwt/flow_lwt_hvsock.ml
@@ -109,7 +109,7 @@ type 'a io = 'a Lwt.t
 type buffer = Cstruct.t
 
 type error = [ `Unix of Unix.error ]
-let pp_error = Bos.OS.U.pp_error
+let pp_error ppf (`Unix e) = Fmt.string ppf (Unix.error_message e)
 type write_error = [ Mirage_flow.write_error | error ]
 let pp_write_error ppf = function
   |#Mirage_flow.write_error as e -> Mirage_flow.pp_write_error ppf e

--- a/lwt/flow_lwt_hvsock_shutdown.ml
+++ b/lwt/flow_lwt_hvsock_shutdown.ml
@@ -62,7 +62,7 @@ type 'a io = 'a Lwt.t
 type buffer = Cstruct.t
 
 type error = [ `Unix of Unix.error ]
-let pp_error = Bos.OS.U.pp_error
+let pp_error ppf (`Unix e) = Fmt.string ppf (Unix.error_message e)
 type write_error = [ Mirage_flow.write_error | error ]
 
 let pp_write_error ppf = function

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        hvsock_lwt)
   (public_name hvsock.lwt)
-  (libraries   (lwt hvsock bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration bos))
+  (libraries   (lwt hvsock bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration))
   (flags       (:standard -safe-string -principal -strict-sequence))
   (wrapped     false)
 ))

--- a/lwt_unix/jbuild
+++ b/lwt_unix/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        hvsock_lwt_unix)
   (public_name hvsock.lwt-unix)
-  (libraries   (lwt hvsock hvsock.lwt bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration lwt.preemptive bos))
+  (libraries   (lwt hvsock hvsock.lwt bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration lwt.preemptive))
   (flags       (:standard -safe-string -principal -strict-sequence))
   (wrapped     false)
 ))

--- a/lwt_unix/jbuild
+++ b/lwt_unix/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        hvsock_lwt_unix)
   (public_name hvsock.lwt-unix)
-  (libraries   (lwt hvsock hvsock.lwt bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration lwt.preemptive))
+  (libraries   (lwt hvsock hvsock.lwt bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration lwt.unix))
   (flags       (:standard -safe-string -principal -strict-sequence))
   (wrapped     false)
 ))


### PR DESCRIPTION
- remove trivial dependency on `bos` (only needed for calling `Unix.error_message`)
- bump minimum `lwt` version to `3.2.0`: the version where `lwt.unix` became an alias for `lwt.preemptive`