### PR TITLE
Add a notion of `shutdown`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,5 @@ env:
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - PACKAGE="hvsock"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.04.2
-   - DISTRO=debian-testing OCAML_VERSION=4.03.0
-   - DISTRO=debian-unstable OCAML_VERSION=4.04.2
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0
-   - DISTRO=centos-7 OCAML_VERSION=4.04.2
-   - DISTRO=fedora-25 OCAML_VERSION=4.04.2
    - DISTRO=alpine OCAML_VERSION=4.03.0
+   - DISTRO=alpine OCAML_VERSION=4.06.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 sudo: false
 env:
  global:
-   - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - PACKAGE="hvsock"
  matrix:
    - DISTRO=alpine OCAML_VERSION=4.03.0

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -25,6 +25,7 @@ depends: [
   "logs"
   "fmt"
   "cmdliner"
+  "sha"
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "cstruct" {>= "2.4.0"}

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -26,6 +26,7 @@ depends: [
   "fmt"
   "cmdliner"
   "sha"
+  "uri"
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "cstruct" {>= "2.4.0"}

--- a/lib/hvsock_stubs.c
+++ b/lib/hvsock_stubs.c
@@ -345,7 +345,7 @@ stub_hvsock_ba_sendv(value fd, value val_list)
   CAMLparam2(fd, val_list);
   CAMLlocal5(next, head, val_buf, val_ofs, val_len);
   SOCKET s = Socket_val(fd);
-  DWORD err = 0;
+  DWORD err;
   DWORD sent = 0;
   int ret = 0;
   int length = 0;

--- a/lwt/flow_lwt_hvsock.ml
+++ b/lwt/flow_lwt_hvsock.ml
@@ -285,15 +285,10 @@ let close t =
     Lwt.return ()
 
 let shutdown_read t =
-  (* When we shutdown_read we don't care about any buffered data. *)
-  Log.warn (fun f -> f "FLOW.shutdown_read called");
-  match t.shutdown_read || t.closed with
-  | true ->
-    Lwt.return_unit
-  | false ->
-    Log.debug (fun f -> f "shutdown_read <- true");
-    t.shutdown_read <- true;
-    Hvsock.shutdown_read t.fd
+  (* We don't care about shutdown_read. We care about shutdown_write because
+     we want to send an EOF to the remote and still receive a response. *)
+  Log.warn (fun f -> f "FLOW.shutdown_read called and ignored");
+  Lwt.return_unit
 
 let shutdown_write t =
   (* When we shutdown_write we still expect buffered data to be flushed. *)

--- a/lwt/flow_lwt_hvsock.ml
+++ b/lwt/flow_lwt_hvsock.ml
@@ -263,7 +263,7 @@ let detach f x =
     (fun () -> Fn.destroy fn; Lwt.return_unit)
 
 let wait_write_flush t =
-  Log.info (fun f -> f "wait_write_flush");
+  Log.debug (fun f -> f "wait_write_flush");
   Mutex.lock t.write_buffers_m;
   while not t.write_flushed do
     Condition.wait t.write_buffers_c t.write_buffers_m
@@ -271,7 +271,7 @@ let wait_write_flush t =
   Mutex.unlock t.write_buffers_m
 
 let close t =
-  Log.warn (fun f -> f "FLOW.close called");
+  Log.debug (fun f -> f "FLOW.close called");
   match t.closed with
   | false ->
     Mutex.lock t.write_buffers_m;
@@ -287,12 +287,12 @@ let close t =
 let shutdown_read t =
   (* We don't care about shutdown_read. We care about shutdown_write because
      we want to send an EOF to the remote and still receive a response. *)
-  Log.warn (fun f -> f "FLOW.shutdown_read called and ignored");
+  Log.debug (fun f -> f "FLOW.shutdown_read called and ignored");
   Lwt.return_unit
 
 let shutdown_write t =
   (* When we shutdown_write we still expect buffered data to be flushed. *)
-  Log.warn (fun f -> f "FLOW.shutdown_write called");
+  Log.debug (fun f -> f "FLOW.shutdown_write called");
   match t.shutdown_write || t.closed with
   | true ->
     Lwt.return ()

--- a/lwt/flow_lwt_hvsock.mli
+++ b/lwt/flow_lwt_hvsock.mli
@@ -20,7 +20,7 @@ module Make(Time: Mirage_time_lwt.S)(Fn: Lwt_hvsock.FN): sig
 
   type error = [ `Unix of Unix.error ]
 
-  include Mirage_flow_lwt.S with type error := error
+  include Mirage_flow_lwt.SHUTDOWNABLE with type error := error
 
   module Hvsock: Lwt_hvsock.HVSOCK
 

--- a/lwt/lwt_hvsock.mli
+++ b/lwt/lwt_hvsock.mli
@@ -65,6 +65,12 @@ module type HVSOCK = sig
 
   val close: t -> unit Lwt.t
   (** [close t] closes a socket *)
+
+  val shutdown_read: t -> unit Lwt.t
+  (** [shutdown_read t] closes the read side of the socket *)
+
+  val shutdown_write: t -> unit Lwt.t
+  (** [shutdown_write t] closes the write side of the socket *)
 end
 
 module Make(Time: Mirage_time_lwt.S)(Fn: FN): HVSOCK

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,6 +1,6 @@
 (executables
- ((names (hvcat))
-  (libraries (cmdliner hvsock hvsock.lwt hvsock.lwt-unix lwt lwt.unix bytes))))
+ ((names (hvcat sock_stress))
+  (libraries (uri sha cmdliner hvsock hvsock.lwt hvsock.lwt-unix lwt lwt.unix))))
 
 (install
  ((section bin)

--- a/src/sock_stress.ml
+++ b/src/sock_stress.ml
@@ -1,0 +1,162 @@
+(*
+ * Copyright (C) 2015 David Scott <dave.scott@unikernel.com>
+ * Copyright (C) 2016 Docker Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Lwt
+
+let sigint_t, sigint_u = Lwt.task ()
+
+open Cmdliner
+
+let default_serviceid =
+  Printf.sprintf "%08x-FACB-11E6-BD58-64006A7986D3" 0x5653 (* matches virtsock/cmd/sock_stress/vsock.go *)
+
+let buffer_size = 4096
+
+module Time = struct
+  type 'a io = 'a Lwt.t
+  let sleep_ns ns = Lwt_unix.sleep (Duration.to_f ns)
+end
+module Hv = Flow_lwt_hvsock.Make(Time)(Lwt_hvsock_detach)
+
+let rec connect vmid serviceid =
+  let fd = Hv.Hvsock.create () in
+  Lwt.catch
+    (fun () ->
+      Hv.Hvsock.connect fd { Hvsock.vmid; serviceid }
+      >>= fun () ->
+      let flow = Hv.connect fd in
+      Lwt.return flow
+    ) (fun e ->
+      Printf.fprintf stderr "connect raised %s: sleep 1s and retrying\n%!" (Printexc.to_string e);
+      Hv.Hvsock.close fd
+      >>= fun () ->
+      Lwt_unix.sleep 1.
+      >>= fun () ->
+      connect vmid serviceid
+    )
+
+let send_receive_verify flow =
+  let reader_sha = Sha256.init () in
+  let rec reader n =
+    Printf.fprintf stderr "about to read\n%!";
+    Hv.read flow
+    >>= function
+    | Ok `Eof ->
+      Printf.fprintf stderr "Reader read total %d bytes\n%!" n;
+      Lwt.return ()
+    | Ok (`Data buf) ->
+      Printf.fprintf stderr "read(%d)\n%!" (Cstruct.len buf);
+      let s = Cstruct.to_string buf in
+      Sha256.update_string reader_sha s;
+      reader (n + (Cstruct.len buf))
+    | Error _ ->
+      failwith "Flow read error" in
+  let writer_sha = Sha256.init () in
+  let rec writer n remaining =
+    if remaining = 0 then begin
+      (* FIXME: this really should be close *)
+      Hv.shutdown_write flow
+      >>= fun () ->
+      Printf.fprintf stderr "Writer wrote total %d bytes\n%!" n;
+      Lwt.return ()
+    end else begin
+      let this_time = min buffer_size remaining in
+      let buf = Cstruct.create this_time in
+      for i = 0 to Cstruct.len buf - 1 do
+        Cstruct.set_uint8 buf i (Random.int 255)
+      done;
+      let s = Cstruct.to_string buf in
+      Printf.fprintf stderr "about to write\n%!";
+      Hv.write flow buf
+      >>= function
+      | Ok () ->
+        Printf.fprintf stderr "write(%d)\n%!" n;
+        Sha256.update_string writer_sha s;
+        writer n (remaining - this_time)
+      | Error _ ->
+        Printf.fprintf stderr "write failed\n%!";
+        failwith "Flow write error"
+    end in
+  (* let n = Random.int (1024 * 1024) in *)
+  let n = 1024 in
+  Printf.fprintf stderr "starting threads\n%!";
+  writer n n
+  >>= fun () ->
+  reader 0
+  >>= fun () ->
+  (* Lwt.join [ reader 0; writer n n ]
+  >>= fun () -> *)
+  let reader = Sha256.(to_hex @@ finalize reader_sha) in
+  let writer = Sha256.(to_hex @@ finalize writer_sha) in
+  Printf.printf "reader = %s\nwriter = %s\n" reader writer;
+  Lwt.return_unit
+
+let client vmid =
+  try
+    connect vmid default_serviceid
+    >>= fun flow ->
+    Printf.fprintf stderr "Connected\n%!";
+    send_receive_verify flow
+    >>= fun () ->
+    Printf.fprintf stderr "Closing\n%!";
+    Hv.close flow
+  with
+  | Unix.Unix_error(Unix.ENOENT, _, _) ->
+    Printf.fprintf stderr "Server not found (ENOENT)\n";
+    Lwt.return ()
+
+let main c =
+  match c with
+  | None ->
+    Printf.fprintf stderr "Please provide a -c hvsock://<vmid> argument\n";
+    exit 1
+  | Some uri ->
+    let u = Uri.of_string uri in
+    begin match Uri.scheme u, Uri.host u with
+    | Some "hvsock", Some vmid ->
+      Lwt_main.run (client (Hvsock.Id vmid));
+      `Ok ()
+    | _, _ ->
+      Printf.fprintf stderr "Please provide a -c hvsock://<vmid> argument\n";
+      exit 1
+    end
+
+(* Note we try to keep the command-line compatible with the Go
+   virtsock/cmd/sock_stress *)
+
+let c =
+  Arg.(value & opt (some string) None & info ~docv:"CLIENT" ~doc:"Run as a client" [ "c" ])
+
+let cmd =
+  let doc = "Test AF_HVSOCK connections" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Establish a connection to an echo server via a Hyper-V socket, send random data, receive a response and check the data is the same. ";
+    `S "EXAMPLES";
+    `P "To connect to a service in a remote partition:";
+    `P "sock_stress -c hvsock://<vmid>";
+  ] in
+  Term.(const main $ c),
+  Term.info "sock_stress" ~version:"%0.1" ~doc ~exits:Term.default_exits ~man
+
+let () =
+let (_: Lwt_unix.signal_handler_id) = Lwt_unix.on_signal Sys.sigint
+  (fun (_: int) ->
+    Lwt.wakeup_later sigint_u ();
+  ) in
+  Term.exit @@ Term.eval cmd

--- a/src/sock_stress.ml
+++ b/src/sock_stress.ml
@@ -104,8 +104,7 @@ let send_receive_verify i flow =
           failwith "Flow write error"
       end in
     loop n in
-  (* let n = Random.int (1024 * 1024) in *)
-  let n_written = 1024 in
+  let n_written = Random.int (1024 * 1024) in
   let writer_t = writer n_written in
   let reader_t = reader 0 in
   Lwt.join [ (reader_t >>= fun _ -> Lwt.return ()); writer_t ]


### PR DESCRIPTION
Previously we always layered our own framing protocol on top because the Hyper-V socket drivers didn't perform half-close / shutdown properly. Now that some of the implementations have been fixed
we would like to use it and remove our hacky protocol.

Signed-off-by: David Scott <dave@recoil.org>