### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/hvsock.opam
+++ b/hvsock.opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "cstruct" {>= "2.4.0"}
   "duration"
-  "dune" {build}
+  "dune"
   "alcotest" {test & >= "0.4.0"}
 ]
 


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.