### PR TITLE
Update to latest base64, opam and fix Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.git

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -33,6 +33,12 @@ depends: [
   "dune" {build}
   "alcotest" {with-test & >= "0.4.0"}
 ]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+]
 synopsis: "Bindings for Hyper-V AF_VSOCK"
 description: """
 [![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -27,7 +27,7 @@ depends: [
   "cmdliner"
   "sha"
   "uri"
-  "base64"
+  "base64" (>= "3.0.0")
   "uuidm"
   "uutf"
   "mirage-flow-lwt" {>= "1.2.0"}

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "cstruct" {>= "2.4.0"}
   "duration"
-  "dune"
+  "dune" {build}
   "alcotest" {test & >= "0.4.0"}
 ]
 

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -1,9 +1,9 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "dave@recoil.org"
 authors: [ "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-hvsock"
-dev-repo: "https://github.com/mirage/ocaml-hvsock.git"
+dev-repo: "git+https://github.com/mirage/ocaml-hvsock.git"
 bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
 doc: "https://mirage.github.io/ocaml-hvsock"
 
@@ -12,12 +12,8 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
-build-test:[
-  [ "dune" "subst" ] {pinned}
-  [ "dune" "runtest" "-p" name "-j" jobs ]
-]
-
 depends: [
+  "ocaml" {>= "4.03.0"}
   "base-bytes"
   "base-threads"
   "base-unix"
@@ -27,7 +23,7 @@ depends: [
   "cmdliner"
   "sha"
   "uri"
-  "base64" (>= "3.0.0")
+  "base64" {>= "3.0.0"}
   "uuidm"
   "uutf"
   "mirage-flow-lwt" {>= "1.2.0"}
@@ -35,11 +31,18 @@ depends: [
   "cstruct" {>= "2.4.0"}
   "duration"
   "dune" {build}
-  "alcotest" {test & >= "0.4.0"}
+  "alcotest" {with-test & >= "0.4.0"}
 ]
+synopsis: "Bindings for Hyper-V AF_VSOCK"
+description: """
+[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
 
-depexts: [
-  [["alpine"] ["linux-headers"]]
-]
+These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
+and Windows.
 
-available: [ ocaml-version >= "4.03.0" ]
+*Warning*: the `AF_HYPERV` patches for Linux are not yet merged and hence the
+definition of `AF_HYPERV` is not yet stable. If other address families are merged
+before this one then the value of `AF_HYPERV` will change!
+
+Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html)."""

--- a/lib/af_hyperv.ml
+++ b/lib/af_hyperv.ml
@@ -106,7 +106,9 @@ let with_powershell script f =
     for i = 0 to String.length script - 1 do
       Uutf.Buffer.add_utf_16le b (Uchar.of_char script.[i])
     done;
-    B64.encode (Buffer.contents b) in
+    match Base64.encode (Buffer.contents b) with
+    | Ok x -> x
+    | Error (`Msg y) -> failwith ("Base64.encode failed unexpectedly: " ^ y) in
 
   let ic = Unix.open_process_in ("powershell.exe -Sta -NonInteractive -ExecutionPolicy RemoteSigned -EncodedCommand  "^ encoded) in
   let closed = ref false in


### PR DESCRIPTION
- Update to use the latest base64 API
- Update opam file to v2
- Use a multi-stage Dockerfile to build `hvcat` as a simple utility