### PR TITLE
Update to new Mirage signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ env:
  global:
    - PACKAGE="hvsock"
  matrix:
-   - DISTRO=alpine OCAML_VERSION=4.03.0
    - DISTRO=alpine OCAML_VERSION=4.06.0

--- a/hvsock.opam
+++ b/hvsock.opam
@@ -1,17 +1,25 @@
 opam-version: "2.0"
+synopsis: "Bindings for Hyper-V AF_VSOCK"
+description: """\
+[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
+
+These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
+and Windows.
+
+*Warning*: the `AF_HYPERV` patches for Linux are not yet merged and hence the
+definition of `AF_HYPERV` is not yet stable. If other address families are merged
+before this one then the value of `AF_HYPERV` will change!
+
+Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html)."""
 maintainer: "dave@recoil.org"
-authors: [ "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"]
+authors: [
+  "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"
+]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-hvsock"
-dev-repo: "git+https://github.com/mirage/ocaml-hvsock.git"
-bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
 doc: "https://mirage.github.io/ocaml-hvsock"
-
-build: [
-  [ "dune" "subst" ] {pinned}
-  [ "dune" "build" "-p" name "-j" jobs ]
-]
-
+bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
@@ -26,12 +34,17 @@ depends: [
   "base64" {>= "3.0.0"}
   "uuidm"
   "uutf"
-  "mirage-flow-lwt" {>= "1.2.0"}
-  "mirage-time-lwt" {>= "1.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
   "cstruct" {>= "2.4.0"}
   "duration"
   "dune" {>= "1.2.0"}
   "alcotest" {with-test & >= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
@@ -39,16 +52,4 @@ depexts: [
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
-synopsis: "Bindings for Hyper-V AF_VSOCK"
-description: """
-[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
-[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
-
-These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
-and Windows.
-
-*Warning*: the `AF_HYPERV` patches for Linux are not yet merged and hence the
-definition of `AF_HYPERV` is not yet stable. If other address families are merged
-before this one then the value of `AF_HYPERV` will change!
-
-Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html)."""
+dev-repo: "git+https://github.com/mirage/ocaml-hvsock.git"

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,6 +1,6 @@
 (library
  (name        hvsock_lwt)
  (public_name hvsock.lwt)
- (libraries   lwt hvsock bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration)
+ (libraries   lwt hvsock bytes mirage-time mirage-flow-combinators cstruct mirage-flow logs threads duration)
  (flags       (:standard -safe-string -principal -strict-sequence))
 )

--- a/lwt/flow.ml
+++ b/lwt/flow.ml
@@ -23,15 +23,11 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(Time: Mirage_time_lwt.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S) = struct
+module Make(Time: Mirage_time.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S) = struct
 
 module Blocking_socket = Socket_family
 module Socket = Socket.Make(Time)(Fn)(Socket_family)
 module RWBuffering = Buffering.Make(Fn)(Socket_family)
-
-type 'a io = 'a Lwt.t
-
-type buffer = Cstruct.t
 
 type error = [ `Unix of Unix.error ]
 let pp_error ppf (`Unix e) = Fmt.string ppf (Unix.error_message e)

--- a/lwt/flow.mli
+++ b/lwt/flow.mli
@@ -16,12 +16,12 @@
  *
  *)
 
-module Make(Time: Mirage_time_lwt.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S): sig
+module Make(Time: Mirage_time.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S): sig
   (** A buffered Mirage FLOW implementation over a hypervisor socket *)
 
   type error = [ `Unix of Unix.error ]
 
-  include Mirage_flow_lwt.SHUTDOWNABLE with type error := error
+  include Mirage_flow_combinators.SHUTDOWNABLE with type error := error
 
   module Socket: S.SOCKET with type sockaddr = Socket_family.sockaddr
 

--- a/lwt/flow_shutdown.ml
+++ b/lwt/flow_shutdown.ml
@@ -53,13 +53,9 @@ end
 
 open Lwt.Infix
 
-module Make(Time: Mirage_time_lwt.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S) = struct
+module Make(Time: Mirage_time.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S) = struct
 
 module Socket = Socket.Make(Time)(Fn)(Socket_family)
-
-type 'a io = 'a Lwt.t
-
-type buffer = Cstruct.t
 
 type error = [ `Unix of Unix.error ]
 let pp_error ppf (`Unix e) = Fmt.string ppf (Unix.error_message e)

--- a/lwt/flow_shutdown.mli
+++ b/lwt/flow_shutdown.mli
@@ -21,7 +21,7 @@
     https://github.com/rneugeba/virtsock/tree/master/go/hvsock
 *)
 
-module Make(Time: Mirage_time_lwt.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S): sig
+module Make(Time: Mirage_time.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S): sig
 
   (** A Mirage FLOW over a hypervisor socket with an additional protocol layer to
       workaround bugs where in-flight data is lost after a shutdown_write or a close.
@@ -29,7 +29,7 @@ module Make(Time: Mirage_time_lwt.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S
 
   type error = [ `Unix of Unix.error ]
 
-  include Mirage_flow_lwt.SHUTDOWNABLE with type error := error
+  include Mirage_flow_combinators.SHUTDOWNABLE with type error := error
 
   module Socket: S.SOCKET with type sockaddr = Socket_family.sockaddr
 

--- a/lwt/socket.ml
+++ b/lwt/socket.ml
@@ -27,7 +27,7 @@ open Lwt.Infix
       and raise ECONNREFUSED ourselves.
 *)
 
-module Make(Time: Mirage_time_lwt.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S) = struct
+module Make(Time: Mirage_time.S)(Fn: S.FN)(Socket_family: Hvsock.Af_common.S) = struct
 
 type op = {
   file_descr: Socket_family.t;

--- a/lwt/socket.mli
+++ b/lwt/socket.mli
@@ -16,7 +16,7 @@
  *)
 
 module Make
-  (Time: Mirage_time_lwt.S)
+  (Time: Mirage_time.S)
   (Fn: S.FN)
   (Socket_family: Hvsock.Af_common.S):
   S.SOCKET

--- a/lwt_unix/dune
+++ b/lwt_unix/dune
@@ -1,6 +1,6 @@
 (library
  (name        hvsock_lwt_unix)
  (public_name hvsock.lwt-unix)
- (libraries   lwt hvsock hvsock.lwt bytes mirage-time-lwt mirage-flow-lwt cstruct mirage-flow logs threads duration lwt.unix)
+ (libraries   lwt hvsock hvsock.lwt bytes mirage-time mirage-flow-combinators cstruct mirage-flow logs threads duration lwt.unix)
  (flags       (:standard -safe-string -principal -strict-sequence))
 )

--- a/lwt_unix/flow.mli
+++ b/lwt_unix/flow.mli
@@ -17,7 +17,7 @@
 
 type error = [`Unix of Unix.error]
 
-include Mirage_flow_lwt.S with type error := error
+include Mirage_flow.S with type error := error
 
  module Socket: Hvsock_lwt.S.SOCKET with type sockaddr = Hvsock.Af_hyperv.sockaddr
 

--- a/lwt_unix/flow_shutdown.mli
+++ b/lwt_unix/flow_shutdown.mli
@@ -17,7 +17,7 @@
 
 type error = [`Unix of Unix.error]
 
-include Mirage_flow_lwt.SHUTDOWNABLE with type error := error
+include Mirage_flow_combinators.SHUTDOWNABLE with type error := error
 
  module Socket: Hvsock_lwt.S.SOCKET with type sockaddr = Hvsock.Af_hyperv.sockaddr
 

--- a/lwt_unix/time.ml
+++ b/lwt_unix/time.ml
@@ -14,6 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-type 'a io = 'a Lwt.t
-
 let sleep_ns ns = Lwt_unix.sleep (Duration.to_f ns)

--- a/lwt_unix/time.mli
+++ b/lwt_unix/time.mli
@@ -14,4 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-include Mirage_time_lwt.S
+include Mirage_time.S


### PR DESCRIPTION
This removes the use of the obsolete `mirage-time-lwt` and `mirage-flow-lwt` libraries, allowing the library to be used with modern versions of lwt.

Note: the order of the fields in the opam file also got updated to opam's preferred format by opam-dune-lint.

Only tested briefly, on Linux.